### PR TITLE
Fix :command argument usage in make-process

### DIFF
--- a/flymake-go-staticcheck.el
+++ b/flymake-go-staticcheck.el
@@ -21,7 +21,7 @@
 
 ;;; URL: https://github.com/s-kostyaev/flymake-go-staticcheck
 
-;;; Package-Requires: ((emacs "25"))
+;;; Package-Requires: ((emacs "26.1"))
 
 ;;; Commentary:
 


### PR DESCRIPTION
When `flymake-go-staticcheck-executable-args` is nil, staticcheck reports a following error:

```
  -: named files must be .go files:
```

Because `make-process` does not concatenate `:command` strings, an empty string is also an argument.

This PR fixes this issue by allowing `flymake-go-staticcheck-executable-args` to accept both strings and lists.
