### PR TITLE
Pass directory to staticcheck instead of file

### DIFF
--- a/flymake-go-staticcheck.el
+++ b/flymake-go-staticcheck.el
@@ -104,7 +104,7 @@ is a buffer containing stdout from linter."
            :buffer (generate-new-buffer " *flymake-go-staticcheck*")
            :command `(,flymake-go-staticcheck-executable
                       ,@args
-                      ,(buffer-file-name source-buffer))
+                      ,(file-name-directory (buffer-file-name source-buffer)))
            :sentinel (lambda (proc &rest ignored)
                        (when (and (eq 'exit (process-status proc))
                                   (with-current-buffer source-buffer (eq proc flymake-go-staticcheck--process)))


### PR DESCRIPTION
staticcheck requires a package as an argument, not a file.
Passing the file also works, but in this case staticcheck does not find symbols in the same package.

This PR based on previous PR https://github.com/s-kostyaev/flymake-go-staticcheck/pull/2